### PR TITLE
Fix/test trade service test

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Set up the trading application in your local environment and ensure both backend
 
 ### Key Resources
 - **Detailed Setup Guide**: See `PROJECT-SETUP-GUIDE.md`
-- **Database Console**: JDBC URL: `jdbc:h2:file:./data/tradingdb`, User: `sa`, Password: (empty)
+- **Database Console**: JDBC URL: `jdbc:h2:file:./data/tradingdb`, User: `sa`, Password: password
 
 ---
 
@@ -81,7 +81,6 @@ For each test fix, document:
 - ✅ Proper Git commit messages following required format
 
 ### Templates
-- **Documentation**: `test-fixes-template.md`
 - **Git Standards**: `git-commit-standards.md`
 - **Self-Assessment**: `test-fix-checklist.md`
 


### PR DESCRIPTION
fix(test): TradeServiceTest - added mocks and fixed date assertion

- Problem: 
TradeServiceTest was failing with NPEs and wrong date assertion.
- Root Cause: 
Tests relied on repository lookups (book/counterparty/trade status) that weren't mocked 
and the test expected a wrong error message.
- Solution: 
Added mocks for BookRepository, CounterpartyRepository and TradeStatusRepository; 
ensured tradeLegRepository.save sets legId; fixed invalid-date assertion to match service message; 
lenient Mockito used while iterating.
- Impact: 
TradeServiceTest now passes and prevents runtime NPEs during create/amend flows. 
Ready to validate cashflow calculation next.